### PR TITLE
Adapt povray.scad to work with modern OpenSCAD

### DIFF
--- a/povray.scad
+++ b/povray.scad
@@ -63,7 +63,7 @@ module pov(s,c) // s = string to print out, c = optional end of line comment
     }    
 }       
 module povc(c) pov("",c); // a single line of comment
-module pove(e) pov(str("##### ERROR #####: ", e)); // POVRAY with error message 
+module pove(e) pov(str("// ##### ERROR #####: ", e)); // POVRAY with error message
 module povm() povc(str("module ", parent_module($parent_modules-1))); // comment with the name of the current module
 
 function parameter(n,v) = (v == undef ? str("  /* ",n, " not defined*/") : str(indentstr, n, " ",v, "  "));
@@ -309,25 +309,25 @@ module _color(v,c="")
 
 // not implemented 3D transformations
 
-module _resize()
+module _resize(c="")
 {
-   pov(str("union { ", "substitute for resize()")); // child bounding box is needed for a 'resize'
+   pov(str("union { ", "// substitute for resize()")); // child bounding box is needed for a 'resize'
    pove("resize() not translated, subsituted by a union()");
    resize() { children([0:$children-1]); }
    pov(str("} ", c));
 }
 
-module _hull()
+module _hull(c="")
 {
-   pov(str("union { ", "substitute for hull()"));
+   pov(str("union { ", "// substitute for hull()"));
    pove("hull() not translated, subsituted by a union()");
    hull() { children([0:$children-1]); }
    pov(str("} ", c));
 }
 
-module _minkowski()
+module _minkowski(c="")
 {
-   pov(str("union { ", "subsitute for minkowski()"));
+   pov(str("union { ", "// substitute for minkowski()"));
    pove("minkowski() not translated, subsituted by a union()");
    minkowski() { children([0:$children-1]); }
    pov(str("} ", c));

--- a/povray.scad
+++ b/povray.scad
@@ -16,7 +16,7 @@ pov_gen=1;
 
 openscad_vpr = $vpr;
 openscad_vpt = $vpt;
-openscad_vpd = 500; // openscad issue #839;
+openscad_vpd = $vpd;
 openscad_vpw = 800;
 openscad_vph = 450;
 
@@ -183,10 +183,8 @@ module openscad2povray_init()
 module _cube(size = [1, 1, 1], center = false)
 {
     cube(size,center);
-    assign(psize = (len(size)==undef ? [size,size,size] : size))
-    {
-        pov(str("box {", center ? strv(-psize/2) : strv([0,0,0]),",", strv(psize/(center ? 2 : 1)), "}" ));
-    }
+    psize = len(size)==undef ? [size,size,size] : size;
+    pov(str("box {", center ? strv(-psize/2) : strv([0,0,0]),",", strv(psize/(center ? 2 : 1)), "}" ));
 }
 
 module _sphere(r=1)
@@ -212,7 +210,8 @@ module __multisided_cone(r1,r2,h,center)
 
 module _cylinder(r1,r2,r = 1,h = 1, center = false)
 {
-    assign(r1 = (r1==undef ? r : r1), r2 = (r2 == undef ? r : r2))
+    r1 = r1==undef ? r : r1;
+    r2 = r2 == undef ? r : r2;
     {
         cylinder(r1=r1,r2=r2,h=h,center=center);
         if ($fn>0 && $fn<30) 
@@ -285,16 +284,11 @@ module _scale(v,c="")
   __object_close("scale",strv(v));
 }
 
-module __multmatrix(m,c="")
+module _multmatrix(m,c="")
 {
   __object_open("multimatrix", $children,c);
   multmatrix(m) { children([0:$children-1]); }
   __object_close("matrix",strv([m[0][0],m[1][0],m[2][0],m[0][1],m[1][1],m[2][1],m[0][2],m[1][2],m[2][2],m[0][3],m[1][3],m[2][3]]));
-}
-
-module _multmatrix(m,c="")
-{
-    __multmatrix(m,c);
 }
 
 module _mirror(v)
@@ -390,4 +384,3 @@ module _group()
   if ($children>0) group() { children([0:$children-1]); }
   pov(str("}"));
 }
-


### PR DESCRIPTION
  - openscad_vpd can now be set by default to $vpd as
    the underlying OpenSCAD feature request is implemented.
  - _multimatrix delegated to __multimatrix which made it not see
    the $children. Use it directly.
  - use direct variable assignments, not deprecated assign()