### PR TITLE
Add Makefile to automate steps towards POV or PNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OpenSCAD2POV-Ray is a OpenSCAD library that allows you to convert OpenSCAD scrip
 ## Setups:
 
 ### Direct wrapper function substitutions
-* Advantage: 
+* Advantage:
  * one step less in the workflow (no intermediate csg file)
  * [future: custom textures could be possible too]
 * Disadvantage
@@ -14,14 +14,14 @@ OpenSCAD2POV-Ray is a OpenSCAD library that allows you to convert OpenSCAD scrip
 * Examples:
  * module 'test1()' and module 'test2()' in povray.scad
 
-### Include OpenSCAD CSG file 
+### Include OpenSCAD CSG file
 * Advantage
  * all aternative ways of specifying parameters supported
 * Disadvantage
  * Extra step of exporting the CSG file
 * Examples
- * radial6 from thingiverse 
-  * preview model `radial6.scad` 
+ * radial6 from thingiverse
+  * preview model `radial6.scad`
   * export CSG as -> `radial6.csg`
   * subsitute `^(\s*)([a-z])` by `$1_$2` and save as  -> `radial6.pov.csg`
   * create file `radial6.pov.scad` as follows:
@@ -31,8 +31,21 @@ OpenSCAD2POV-Ray is a OpenSCAD library that allows you to convert OpenSCAD scrip
     include <radial6.pov.csg>
 ```
   * preview model `radial6.pov.scad`
-  * copy all lines starting with `ECHO: "POVRAY:` (use right mouse click) 
+  * copy all lines starting with `ECHO: "POVRAY:` (use right mouse click)
   * paste in new file as save -> `radial6.pov`
   * remove `ECHO: "POVRAY:` and trailing `"` from file `radial6.pov`
   * render `radial6.pov` in POV-Ray
 
+### Use Makefile
+
+The above rules and dependencies have been put together in the
+[`Makefile`](test%20radial6/Makefile) in the sample project.
+
+The rules are described in pattern format, so it is easy to re-use in your
+own project Makefiles.
+
+```bash
+cd "test radial6/"
+make radial6.pov   # to create the povray file from the radial6.scad file.
+make radial6.png   # to also render it directly as PNG
+```

--- a/test radial6/Makefile
+++ b/test radial6/Makefile
@@ -1,0 +1,35 @@
+# Where the povray.scad file is located
+POVRAY_SCAD=../povray.scad
+
+# Desired picture size
+POVRAY_WIDTH=2048
+POVRAY_HEIGHT=2048
+
+# Get good translation and rotation matrix from the OpenSCAD status line.
+OPENSCAD_VPT=[-35, 29, 42]
+OPENSCAD_VPR=[59.2, 0, 45.3]
+OPENSCAD_DISTANCE=1000
+
+all: radial6.png
+
+%.csg : %.scad
+	openscad $< -o $@
+
+%.pov.csg : %.csg
+	sed 's/^\(\s*\)\([a-z]\)/\1_\2/' < $< > $@
+
+%.pov.scad: %.pov.csg
+	echo "use <$(POVRAY_SCAD)>\nopenscad2povray_init();\ninclude <$<>" > $@
+
+%.echo : %.scad $(POVRAY_SCAD)
+	openscad -Dopenscad_vpw=$(POVRAY_WIDTH) \
+                 -Dopenscad_vph=$(POVRAY_HEIGHT) \
+                 -D'$$vpd=$(OPENSCAD_DISTANCE)' \
+                 -D'$$vpt=$(OPENSCAD_VPT)' -D'$$vpr=$(OPENSCAD_VPR)' \
+                 $< -o $@
+
+%.pov : %.pov.echo
+	sed -e 's/^ECHO: "POVRAY:\(.*\)"/\1/p;d' < $< | sed -e 's/\s*$$//' > $@
+
+%.png : %.pov
+	povray +W$(POVRAY_WIDTH) +H$(POVRAY_HEIGHT) -D +FN12 +UA +A +AM2 $<

--- a/test radial6/Makefile
+++ b/test radial6/Makefile
@@ -12,7 +12,7 @@ OPENSCAD_DISTANCE=1000
 
 all: radial6.png
 
-%.csg : %.scad
+%.csg : %.scad Makefile
 	openscad $< -o $@
 
 %.pov.csg : %.csg


### PR DESCRIPTION
The involved recipe how to create a povray file from an SCAD file
is the perfect candidate to write as Makefile.

Added a Makefile in the "test radial6/" directory that takes care
of all the tedious steps, with rules to directly output a
%.pov or %.png.

It also provides a nice template for someone new to get started.